### PR TITLE
Debug

### DIFF
--- a/lemsynth/lemsynth_engine.py
+++ b/lemsynth/lemsynth_engine.py
@@ -142,7 +142,7 @@ def solveProblem(lemma_grammar_args, lemma_grammar_terms, goal, name, grammar_st
                 print('total lemmas so far: ' + str(config_params['analytics']['total_lemmas']))
 
             if z3py_lemma in invalid_lemmas or z3py_lemma in valid_lemmas:
-                if options.use_cex_models:
+                if options.use_cex_models or options.use_cex_true_models:
                     print('lemma has already been proposed')
                     if z3py_lemma in invalid_lemmas:
                         print('Something is wrong. Lemma was re-proposed in the presence of countermodels. '

--- a/lemsynth/lemsynth_engine.py
+++ b/lemsynth/lemsynth_engine.py
@@ -201,11 +201,10 @@ def solveProblem(lemma_grammar_args, lemma_grammar_terms, goal, name, grammar_st
                     if options.verbose >= 4:
                         print('using true counterexample models')
                     true_model_size = 5
-                    true_cex_model = gen_lfp_model(true_model_size, annctx, invalid_formula=z3py_lemma)
+                    true_cex_model, true_model_terms = gen_lfp_model(true_model_size, annctx, invalid_formula=z3py_lemma)
                     if true_cex_model is not None:
+                        # Use after gen_lfp_model fixes values on elements not in the lfp (as sort.lattice_bottom) 
                         # true_model_terms = {z3.IntVal(elem) for elem in true_cex_model.fg_universe}
-                        # HACK
-                        true_model_terms = {z3.IntVal(i) for i in range(true_model_size)}
                         const = [arg for arg in lemma_grammar_args if not is_var_decl(arg, annctx)]
                         lemma_arity = len(lemma_grammar_args) - len(const)
                         args = itertools.product(true_model_terms, repeat=lemma_arity)

--- a/naturalproofs/extensions/lfpmodels.py
+++ b/naturalproofs/extensions/lfpmodels.py
@@ -370,6 +370,6 @@ def gen_lfp_model(size, annctx, invalid_formula=None):
         lfp_model = sol.model()
         # Project model onto the numbers corresponding to the foreground universe
         finite_lfp_model = FiniteModel(lfp_model, universe, annctx=annctx)
-        return finite_lfp_model
+        return finite_lfp_model, universe
     else:
-        return None
+        return None, None

--- a/naturalproofs/prover.py
+++ b/naturalproofs/prover.py
@@ -61,6 +61,8 @@ class NPSolver:
         :param lemmas: set of z3.BoolRef  
         :return: NPSolution  
         """
+        z3.set_param('smt.random_seed', 0)
+        z3.set_param('sat.random_seed', 0)
         # TODO: check that the given lemmas are legitimate bound formula instances with their formal parameters from
         #  the foreground sort.
         options = self.options


### PR DESCRIPTION
This PR:

(1) Fixes the lemma re-proposal issue using a temporary fix, changing the return signature of naturalproofs/extensions/lfpmodels.get_lfp_model to explicitly provide the foreground universe of the generated model. This is happening because the rank definitions do not address what happens to measures like keys on elements where list(), lseg()..etc does not hold. It needs to be fixed by automatically setting those measures to the lattice_bottom of their respective sorts when the argument is not in the least-fixpoint.

(2) Makes the tool more deterministic by explicitly setting random seeds wherever possible (in the synthesis file as well as the natural proofs solver) to 0. Change not compatible with CVC4 format and may break streaming mode. More tests are required to determine whether the tool is in fact deterministic with these seeds.