### PR TITLE
Lean quantifier instantiation

### DIFF
--- a/lemsynth/grammar_utils.py
+++ b/lemsynth/grammar_utils.py
@@ -36,7 +36,7 @@ def representative_lemmas(lemma_args, lemma_grammar_terms, annctx, future=False)
 def lemma_instantiation_terms(lemma_args, lemma_grammar_terms, annctx):
     example_lemmas = representative_lemmas(lemma_args, lemma_grammar_terms, annctx=annctx)
     pfp_formulas = {make_pfp_formula(lemma, annctx=annctx) for lemma in example_lemmas}
-    instantiation_terms = get_foreground_terms(pfp_formulas)
+    instantiation_terms = get_foreground_terms(pfp_formulas, annctx=annctx)
     # get_foreground_terms already performs subterm closure
     return instantiation_terms
 
@@ -51,6 +51,6 @@ def goal_extraction_terms(goal_instantiation_terms, lemma_args, lemma_grammar_te
     bound_example_lemmas = {(lemma_params, example_lemma) for example_lemma in example_lemmas}
     # Instantiate example lemmas with all possible terms from the instantiation the goal and axioms
     example_instantiations = instantiate(bound_example_lemmas, goal_instantiation_terms)
-    example_extraction_terms = get_foreground_terms(example_instantiations, annctx)
+    example_extraction_terms = get_foreground_terms(example_instantiations, annctx=annctx)
     # Model extraction already performs subterm closure so there is no need to do it here.
     return example_extraction_terms

--- a/lemsynth/lemsynth_engine.py
+++ b/lemsynth/lemsynth_engine.py
@@ -38,8 +38,8 @@ def solveProblem(lemma_grammar_args, lemma_grammar_terms, goal, name, grammar_st
                                           proveroptions.fixed_depth,
                                           proveroptions.lean_instantiation}
     if goal_instantiation_mode is None:
-        # lean instantiation by default
-        goal_instantiation_mode = proveroptions.lean_instantiation
+        # stratified instantiation by default
+        goal_instantiation_mode = proveroptions.depth_one_stratified_instantiation
     elif goal_instantiation_mode not in supported_goal_instantiation_modes:
         # The set of instantiation terms must stay constant
         # TODO: check for unsoundness of algorithm if instantiation mode has automatic adaptive depth.

--- a/lemsynth/lemsynth_engine.py
+++ b/lemsynth/lemsynth_engine.py
@@ -190,7 +190,7 @@ def solveProblem(lemma_grammar_args, lemma_grammar_terms, goal, name, grammar_st
                     # Check that the terms needed from the pfp of the proposed
                     # lemma do not exceed lemma_grammar_terms.
                     # Otherwise finite model extraction will not work.
-                    needed_instantiation_terms = get_foreground_terms(pfp_lemma, annctx)
+                    needed_instantiation_terms = get_foreground_terms(pfp_lemma, annctx=annctx)
                     remaining_terms = needed_instantiation_terms - lemma_instantiation_terms
                     if remaining_terms != set():
                         raise ValueError('lemma_terms is too small.\n'

--- a/lemsynth/lemsynth_engine.py
+++ b/lemsynth/lemsynth_engine.py
@@ -35,10 +35,11 @@ def solveProblem(lemma_grammar_args, lemma_grammar_terms, goal, name, grammar_st
     goal_instantiation_mode = config_params.get('goal_instantiation_mode', None)
     supported_goal_instantiation_modes = {proveroptions.manual_instantiation,
                                           proveroptions.depth_one_stratified_instantiation,
-                                          proveroptions.fixed_depth}
+                                          proveroptions.fixed_depth,
+                                          proveroptions.lean_instantiation}
     if goal_instantiation_mode is None:
-        # depth one stratified instantiation by default
-        goal_instantiation_mode = proveroptions.depth_one_stratified_instantiation
+        # lean instantiation by default
+        goal_instantiation_mode = proveroptions.lean_instantiation
     elif goal_instantiation_mode not in supported_goal_instantiation_modes:
         # The set of instantiation terms must stay constant
         # TODO: check for unsoundness of algorithm if instantiation mode has automatic adaptive depth.

--- a/naturalproofs/extensions/finitemodel.py
+++ b/naturalproofs/extensions/finitemodel.py
@@ -65,7 +65,7 @@ class FiniteModel:
         #  cases where uninterpreted functions have arguments in other domains, primarily integers.
         # Subterm-close the given terms assuming one-way functions
         # get_foreground_terms already performs subterm closure
-        subterm_closure = get_foreground_terms(terms)
+        subterm_closure = get_foreground_terms(terms, annctx=annctx)
         elems = elems | {smtmodel.eval(term, model_completion=True) for term in subterm_closure}
         if vocabulary is None:
             vocabulary = get_vocabulary(annctx)

--- a/naturalproofs/extensions/lfpmodels.py
+++ b/naturalproofs/extensions/lfpmodels.py
@@ -348,6 +348,7 @@ def gen_lfp_model(size, annctx, invalid_formula=None):
     # Recursive definitions and ranks
     recdefs = get_recursive_definition(None, alldefs=True, annctx=annctx)
     recdef_unfoldings = make_recdef_unfoldings(recdefs)
+    untagged_unfoldings = set(recdef_unfoldings.values())
     rank_formulas = {recdef.name(): rank_defs_dict.get(recdef.name(), None) for recdef, _, _ in recdefs}
     if all(value is None for value in rank_formulas.values()):
         raise Exception('Rank definitions must be given at least for the underlying datastructure definition. '
@@ -355,7 +356,7 @@ def gen_lfp_model(size, annctx, invalid_formula=None):
                         .format(', '.join(key for key, value in rank_formulas.items() if value is None)))
     # Axioms
     axioms = get_all_axioms(annctx=annctx)
-    structural_constraints = recdef_unfoldings | set(
+    structural_constraints = untagged_unfoldings | set(
         rankdef for rankdef in rank_formulas.values() if rankdef is not None) | axioms
     constraints.extend(instantiate(structural_constraints, universe))
 

--- a/naturalproofs/prover.py
+++ b/naturalproofs/prover.py
@@ -94,6 +94,7 @@ class NPSolver:
         # Keep track of terms in the quantifier-free problem given to the solver
         initial_terms = get_foreground_terms(neg_goal, annctx=self.annctx)
         extraction_terms = initial_terms
+        recdef_application_terms = get_recdef_applications(neg_goal, annctx=self.annctx)
         instantiation_terms = set()
         # Instantiate and check for provability according to options
         # Handle manual instantiation mode first
@@ -109,7 +110,7 @@ class NPSolver:
             return NPSolution(if_sat=if_sat, model=model, extraction_terms=extraction_terms, 
                               instantiation_terms=instantiation_terms, options=options)
         # Automatic instantiation modes
-        # Untracked lemma instantiation strategy
+        # stratified instantiation strategy
         if options.instantiation_mode == proveroptions.depth_one_stratified_instantiation:
             conservative_fo_abstractions = axioms | recdef_unfoldings
             tracked_instantiations = instantiate(conservative_fo_abstractions, initial_terms)

--- a/naturalproofs/prover_utils.py
+++ b/naturalproofs/prover_utils.py
@@ -6,6 +6,7 @@ import itertools
 
 from naturalproofs.AnnotatedContext import default_annctx
 from naturalproofs.uct import is_expr_fg_sort
+from naturalproofs.decl_api import get_recursive_definition
 from naturalproofs.utils import apply_bound_formula
 
 
@@ -14,19 +15,27 @@ def instantiate(bound_formulas, terms):
     Instantiates every formula in bound_formulas with given terms. Each bound formula is a pair
     (tuple of formal parameters, formula in terms of parameters).  
     :param bound_formulas: (tuple of z3.ExprRef, z3.ExprRef) or a set of such pairs  
-    :param terms: set of z3.ExprRef  
+    :param terms: set of z3.ExprRef or tuple of z3.ExprRef
     :return: set of z3.ExprRef  
     """
     if isinstance(bound_formulas, tuple):
         # Only one bound formula given
         bound_formulas = {bound_formulas}
     instantiated_set = set()
+    terms = list(terms)
     for bound_formula in bound_formulas:
         formal_params, body = bound_formula
         arity = len(formal_params)
         # The arguments are all possible tuples of terms whose length is arity
         # TODO: make this step more efficient by sorting bound_formulas by arity or using numpy.product
-        arg_tuples = itertools.product(terms, repeat=arity)
+        if isinstance(terms[0], z3.ExprRef):
+            # Only individual terms are given. Make argument tuples with them.
+            arg_tuples = itertools.product(terms, repeat=arity)
+        else:
+            # Check that all the tuples are of the same arity
+            if not all(len(term_tup) == arity for term_tup in terms):
+                raise ValueError('Arguments must be the same length as the arity of the bound formula to be applied.')
+            arg_tuples = terms
         for arg_tuple in arg_tuples:
             instantiated_set.add(apply_bound_formula(bound_formula, arg_tuple))
     return instantiated_set
@@ -72,7 +81,7 @@ def _make_recdef_unfoldings_aux(recdef_triple):
     if not isinstance(recdef, z3.FuncDeclRef):
         raise TypeError('FuncDeclRef expected.')
     # The unfolding is simply the fact that the recursive function is equal to its body on the formal parameters.
-    unfolding = (formal_params, recdef(*formal_params) == body)
+    unfolding = {recdef: (formal_params, recdef(*formal_params) == body)}
     return unfolding
 
 
@@ -80,13 +89,54 @@ def make_recdef_unfoldings(recursive_definitions):
     """
     Make a bound formula from the given recursive definition that corresponds to its 'unfolding' once on given input.  
     :param recursive_definitions: (z3.FuncDeclRef, tuple of z3.ExprRef, z3.ExprRef) or a set of such triples  
-    :return: set of (tuple of z3.ExprRef, z3.ExprRef)  
+    :return: dict {z3.FuncDeclRef : (tuple of z3.ExprRef, z3.ExprRef)}
     """
     if not isinstance(recursive_definitions, set):
         # Only one recursive definition given
         return _make_recdef_unfoldings_aux(recursive_definitions)
     else:
-        unfoldings_set = set()
+        unfoldings_dict = dict()
         for recursive_definition in recursive_definitions:
-            unfoldings_set.add(_make_recdef_unfoldings_aux(recursive_definition))
-        return unfoldings_set
+            unfoldings_dict = {**unfoldings_dict, **_make_recdef_unfoldings_aux(recursive_definition)}
+        return unfoldings_dict
+
+
+def _get_recdef_applications_aux(expr, recdefs):
+    decl = expr.decl()
+    arity = decl.arity()
+    applications = []
+    if arity > 0:
+        applications = []
+        if decl in recdefs:
+            applications = applications + [(decl, tuple(expr.children()))]
+        for child in expr.children():
+            applications = applications + _get_recdef_applications_aux(child, recdefs)
+    return applications
+
+
+def get_recdef_applications(exprs, annctx):
+    """
+    Return a dictionary containing tuples that occur under applications of recursive definitions. The dictionary 
+    is indexed by recursive definitions.  
+    :param exprs: z3.ExprRef or set of z3.ExprRef  
+    :param annctx: naturalproofs.AnnotatedContext.AnnotatedContext  
+    :return: dict {z3.FuncDeclRef : list of tuples of z3.ExprRef}
+    """
+    recdef_triples = get_recursive_definition(None, alldefs=True, annctx=annctx)
+    recdefs = [triple[0] for triple in recdef_triples]
+    if isinstance(exprs, z3.ExprRef):
+        # Only one expression given
+        result = _get_recdef_applications_aux(exprs, recdefs)
+    else:
+        result = []
+        for expr in exprs:
+            if not isinstance(expr, z3.ExprRef):
+                raise TypeError('ExprRef expected')
+            result = result + _get_recdef_applications_aux(expr, recdefs)
+    # Make the list of applications into a dictionary
+    applications = dict()
+    for recdef, application in result:
+        if recdef not in applications:
+            applications[recdef] = []
+        applications[recdef].append(application)
+    return applications

--- a/naturalproofs/prover_utils.py
+++ b/naturalproofs/prover_utils.py
@@ -55,7 +55,7 @@ def _get_foreground_terms_aux(expr, annctx):
     return fg_set
 
 
-def get_foreground_terms(exprs, annctx=default_annctx):
+def get_foreground_terms(exprs, annctx):
     """
     Return the subterm-closed set of terms in any expression in exprs that are of the foreground sort.  
     :param exprs: z3.ExprRef or set of z3.ExprRef  

--- a/naturalproofs/proveroptions.py
+++ b/naturalproofs/proveroptions.py
@@ -31,3 +31,4 @@ bounded_depth = 1
 infinite_depth = 2
 manual_instantiation = 3
 depth_one_stratified_instantiation = 4
+lean_instantiation = 5


### PR DESCRIPTION
This PR adds support for 'lean' quantifier instantiation that only unfolds a recursive definition on a tuple if it occur under the application of said definition in the quantifier-free formula given to SMT.
Tests regarding the efficacy of this against the other modes is pending.