### PR TITLE
Lean QI with lemmas

### DIFF
--- a/lemsynth/lemsynth_engine.py
+++ b/lemsynth/lemsynth_engine.py
@@ -36,7 +36,8 @@ def solveProblem(lemma_grammar_args, lemma_grammar_terms, goal, name, grammar_st
     supported_goal_instantiation_modes = {proveroptions.manual_instantiation,
                                           proveroptions.depth_one_stratified_instantiation,
                                           proveroptions.fixed_depth,
-                                          proveroptions.lean_instantiation}
+                                          proveroptions.lean_instantiation,
+                                          proveroptions.lean_instantiation_with_lemmas}
     if goal_instantiation_mode is None:
         # stratified instantiation by default
         goal_instantiation_mode = proveroptions.depth_one_stratified_instantiation

--- a/naturalproofs/proveroptions.py
+++ b/naturalproofs/proveroptions.py
@@ -32,3 +32,4 @@ infinite_depth = 2
 manual_instantiation = 3
 depth_one_stratified_instantiation = 4
 lean_instantiation = 5
+lean_instantiation_with_lemmas = 6


### PR DESCRIPTION
This PR adds an instantiation mode in the natural proofs package. The new instantiation mode only 'triggers' a lemma of the form recdef => phi or a recursive definition unfolding when a tuple of terms occurs under the application of the corresponding recdef. Axioms are treated as usual, and are instantiated with all possible combinations of terms from the quantifier-free formula at each round.